### PR TITLE
chore: add custom declarations for react-syntax-highlighter

### DIFF
--- a/src/@types/declarations.d.ts
+++ b/src/@types/declarations.d.ts
@@ -1,0 +1,2 @@
+declare module "react-syntax-highlighter/dist/esm/styles/prism";
+declare module "react-syntax-highlighter";


### PR DESCRIPTION
This pull request adds custom TypeScript module declarations to fix missing type errors related to react-syntax-highlighter and its Prism styles.
It ensures the project compiles without type issues when using these imports.